### PR TITLE
fix(package.json): Increment @types/node to fix build error

### DIFF
--- a/package.json
+++ b/package.json
@@ -23,7 +23,7 @@
   ],
   "devDependencies": {
     "@types/jest": "23.3.9",
-    "@types/node": "10.12.9",
+    "@types/node": "^15.12.2",
     "@types/react": "16.7.6",
     "@types/react-dom": "16.0.9",
     "jest": "^23.0.0",


### PR DESCRIPTION
When trying to build the library as-is, I get a build error:

TypeScript: Duplicate identifier 'IteratorResult'

Updating @types/node to latest fixes it.