### PR TITLE
upgrade react and react types to same major version

### DIFF
--- a/package.json
+++ b/package.json
@@ -25,20 +25,20 @@
     "@types/jest": "23.3.9",
     "@types/node": "^15.12.2",
     "@types/react": "^17.0.34",
-    "@types/react-dom": "16.0.9",
+    "@types/react-dom": "^17.0.11",
     "jest": "^23.0.0",
     "jest-dom": "^3.0.2",
     "np": "^3.1.0",
-    "react": "^16.7.0",
-    "react-dom": "^16.7.0",
+    "react": "^17.0.2",
+    "react-dom": "^17.0.2",
     "typescript": "^3.3.4000"
   },
   "dependencies": {
     "component-library": "^0.0.1"
   },
   "peerDependencies": {
-    "react": "^16.7.0",
-    "react-dom": "^16.7.0"
+    "react": "^17.0.2",
+    "react-dom": "^17.0.2"
   },
   "jest": {
     "preset": "ts-jest",


### PR DESCRIPTION
To fix `RefCallback` issue

```
Namespace 'React' has no exported member 'RefCallback'.

23 ): React.RefCallback<any> => {
            ~~~~~~~~~~~
```